### PR TITLE
it is now possible to use 0 as min or max for number-groups

### DIFF
--- a/src/addons/group/number.js
+++ b/src/addons/group/number.js
@@ -27,8 +27,12 @@ Xt.mount.push({
       addEl.removeAttribute('disabled')
       removeEl.removeAttribute('disabled')
       // check min and max
-      const inputMin = parseFloat(input.getAttribute('min')) || 1
-      const inputMax = parseFloat(input.getAttribute('max')) || Infinity
+      const minAttributeAsFloat = parseFloat(input.getAttribute('min'));
+      const inputMin = isNaN(minAttributeAsFloat) ? 1 : minAttributeAsFloat;
+
+      const maxAttributeAsFloat = parseFloat(input.getAttribute('max'));
+      const inputMax = isNaN(maxAttributeAsFloat) ? Infinity : maxAttributeAsFloat;
+
       if (val <= inputMin) {
         val = inputMin
         removeEl.setAttribute('disabled', 'disabled')


### PR DESCRIPTION
It is now possible to use 0 as min or max for number-groups, before my commit value 0 was evalued to false and always fallback to the default values